### PR TITLE
fix(api): use any type for `WriteParams.Delete` too

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -850,8 +850,8 @@ type NamespaceWriteParams struct {
 	// The namespace to copy documents from.
 	CopyFromNamespace param.Opt[string] `json:"copy_from_namespace,omitzero"`
 	// The filter specifying which documents to delete.
-	DeleteByFilter Filter    `json:"delete_by_filter,omitzero"`
-	Deletes        []IDParam `json:"deletes,omitzero" format:"uuid"`
+	DeleteByFilter Filter `json:"delete_by_filter,omitzero"`
+	Deletes        []any  `json:"deletes,omitzero"`
 	// A function used to calculate vector similarity.
 	//
 	// Any of "cosine_distance", "euclidean_squared".

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -203,10 +203,8 @@ func TestNamespaceWriteWithOptionalParams(t *testing.T) {
 	_, err := ns.Write(context.TODO(), turbopuffer.NamespaceWriteParams{
 		CopyFromNamespace: turbopuffer.String("copy_from_namespace"),
 		DeleteByFilter:    turbopuffer.NewFilterEq("id", "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"),
-		Deletes: []turbopuffer.IDParam{{
-			String: turbopuffer.String("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"),
-		}},
-		DistanceMetric: turbopuffer.DistanceMetricCosineDistance,
+		Deletes:           []any{"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"},
+		DistanceMetric:    turbopuffer.DistanceMetricCosineDistance,
 		Encryption: turbopuffer.NamespaceWriteParamsEncryption{
 			Cmek: turbopuffer.NamespaceWriteParamsEncryptionCmek{
 				KeyName: "key_name",


### PR DESCRIPTION
To align with `UpsertRows`, `PatchRows`, etc.