### PR TITLE
fix: strict types for async query and multi_query APIs

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -828,18 +828,18 @@ type NamespaceMultiQueryParamsQuery struct {
 	TopK param.Opt[int64] `json:"top_k,omitzero"`
 	// Aggregations to compute over all documents in the namespace that match the
 	// filters.
-	AggregateBy map[string]any `json:"aggregate_by,omitzero"`
+	AggregateBy map[string]AggregateBy `json:"aggregate_by,omitzero"`
 	// A function used to calculate vector similarity.
 	//
 	// Any of "cosine_distance", "euclidean_squared".
 	DistanceMetric DistanceMetric `json:"distance_metric,omitzero"`
 	// Exact filters for attributes to refine search results for. Think of it as a SQL
 	// WHERE clause.
-	Filters any `json:"filters,omitzero"`
+	Filters Filter `json:"filters,omitzero"`
 	// Whether to include attributes in the response.
 	IncludeAttributes IncludeAttributesParam `json:"include_attributes,omitzero"`
 	// How to rank the documents in the namespace.
-	RankBy any `json:"rank_by,omitzero"`
+	RankBy RankBy `json:"rank_by,omitzero"`
 	paramObj
 }
 

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -81,15 +81,11 @@ func TestNamespaceMultiQueryWithOptionalParams(t *testing.T) {
 	_, err := ns.MultiQuery(context.TODO(), turbopuffer.NamespaceMultiQueryParams{
 		Namespace: turbopuffer.String("namespace"),
 		Queries: []turbopuffer.NamespaceMultiQueryParamsQuery{{
-			AggregateBy: map[string]any{
-				"foo": "bar",
-			},
 			DistanceMetric: turbopuffer.DistanceMetricCosineDistance,
-			Filters:        map[string]interface{}{},
 			IncludeAttributes: turbopuffer.IncludeAttributesParam{
 				Bool: turbopuffer.Bool(true),
 			},
-			RankBy: map[string]interface{}{},
+			RankBy: turbopuffer.NewRankByVector("vector", []float32{0}),
 			TopK:   turbopuffer.Int(0),
 		}},
 		Consistency: turbopuffer.NamespaceMultiQueryParamsConsistency{


### PR DESCRIPTION
This type was missing the necessary custom code to stitch in our stricter types for the `aggregate_by`, `filters`, and `rank_by` parameters.