### PR TITLE
Retract versions before v1.12.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,7 @@ require (
 )
 
 require github.com/tidwall/match v1.1.1 // indirect
+
+// Versions before v1.12.2 contain a data race in Client.Namespace.
+// See https://github.com/turbopuffer/turbopuffer-go/pull/88.
+retract [v0.1.0-alpha.1, v1.12.1]


### PR DESCRIPTION
Retract all versions before v1.12.2 to prevent use of versions with a critical data race in `Client.Namespace`. The race condition caused documents to be silently written to incorrect namespaces in production. See https://github.com/turbopuffer/turbopuffer-go/pull/88 for details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only `go.mod` change that affects module version selection but does not alter runtime code paths.
> 
> **Overview**
> Marks all versions `v0.1.0-alpha.1` through `v1.12.1` as **retracted** in `go.mod`, with a note pointing to the `Client.Namespace` data-race fix, so `go` tooling warns/avoids those releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 423ea09a5bae9e672f823f65719436b290cc6a97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->