### PR TITLE
PrettyPrint JSON.Marshal error Obfuscate HTTP Response 

### DIFF
--- a/custom_pretty.go
+++ b/custom_pretty.go
@@ -9,6 +9,9 @@ import (
 
 // PrettyPrint pretty prints a JSON-encodable value to a string.
 func PrettyPrint(v any) string {
+	if err, ok := v.(error); ok {
+		return fmt.Sprintf("<error: %s>", err.Error())
+	}
 	bytes, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Sprintf("<error: %s>", err)

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -145,7 +145,7 @@ func TestNamespaceMultiQueryWithOptionalParams(t *testing.T) {
 	ns := client.Namespace("ns")
 	_, err := ns.MultiQuery(context.TODO(), turbopuffer.NamespaceMultiQueryParams{
 		Namespace: turbopuffer.String("namespace"),
-		Queries: []turbopuffer.NamespaceMultiQueryParamsQuery{{
+		Queries: []turbopuffer.QueryParam{{
 			DistanceMetric:    turbopuffer.DistanceMetricCosineDistance,
 			ExcludeAttributes: []string{"string"},
 			GroupBy:           []string{"string"},


### PR DESCRIPTION
- The purpose PR is to address the issue where PrettyPrint unintentionally obfuscate the HTTP response by failing and overriding the HTTP response error with a json.Marshal error.
- It added additional checking for value `v` being passed into PrettyPrint of type `any`. And since we're mainly concern with type JSON encodable `string` and `apierror.Error`, PrettyPrint will now check the type of the value before trying to marshal the value.
- In the scenario where marshaling string fail due to any reason, it will display the original value without pretty print, while maintaining the core behaviour as expected of a JSON encodable string.

This PR came from my investigation of the capabilities of TurboPuffer SDK while going through the take home assignment of TurboPuffer.

I look forward to the responses and comments on this fix.

PS: Alternatively, a simpler solution would be to print the raw unpretty value if the type is not string, and only check for string, reducing the complexity of the function.