### PR TITLE
docs: add UPGRADING.md with v2.0 breaking changes

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,6 +24,28 @@ changes.
   })
   ```
 
+- `NamespaceQueryParams.GroupBy` is now `[]turbopuffer.GroupBy` instead of
+  `[]string`. Wrap plain attribute names with `turbopuffer.NewGroupByAttr`.
+
+  Old:
+
+  ```go
+  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
+      GroupBy: []string{"color", "size"},
+  })
+  ```
+
+  New:
+
+  ```go
+  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
+      GroupBy: []turbopuffer.GroupBy{
+          turbopuffer.NewGroupByAttr("color"),
+          turbopuffer.NewGroupByAttr("size"),
+      },
+  })
+  ```
+
 - The `encryption` parameter has been restructured.
 
   Old:
@@ -101,26 +123,4 @@ changes.
       "github.com/turbopuffer/turbopuffer-go/v2"
       "github.com/turbopuffer/turbopuffer-go/v2/option"
   )
-  ```
-
-- `NamespaceQueryParams.GroupBy` is now `[]turbopuffer.GroupBy` instead of
-  `[]string`. Wrap plain attribute names with `turbopuffer.NewGroupByAttr`.
-
-  Old:
-
-  ```go
-  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
-      GroupBy: []string{"color", "size"},
-  })
-  ```
-
-  New:
-
-  ```go
-  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
-      GroupBy: []turbopuffer.GroupBy{
-          turbopuffer.NewGroupByAttr("color"),
-          turbopuffer.NewGroupByAttr("size"),
-      },
-  })
   ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -85,8 +85,23 @@ changes.
   A new `Default` variant lets you migrate a namespace from CMEK to default
   encryption.
 
-- The `NewRankByVector` and `NewRankBySparseVector` constructors have been
-  renamed to `NewRankByAnn` and `NewRankBySparseKnn`.
+- The `NewRankByVector` constructor has been renamed to `NewRankByAnn`.
+
+  Old:
+
+  ```go
+  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
+      RankBy: turbopuffer.NewRankByVector("vector", []float32{0.1, 0.2}),
+  })
+  ```
+
+  New:
+
+  ```go
+  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
+      RankBy: turbopuffer.NewRankByAnn("vector", []float32{0.1, 0.2}),
+  })
+  ```
 
 - `NamespaceQueryParams.GroupBy` is now `[]turbopuffer.GroupBy` instead of
   `[]string`. Wrap plain attribute names with `turbopuffer.NewGroupByAttr`.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,15 +6,48 @@ changes.
 
 ## v2.0
 
-- The module path has been bumped to `github.com/turbopuffer/turbopuffer-go/v2`.
-  Update your imports accordingly:
+- The `NewRankByVector` constructor has been renamed to `NewRankByAnn`.
+
+  Old:
 
   ```go
-  import (
-      "github.com/turbopuffer/turbopuffer-go/v2"
-      "github.com/turbopuffer/turbopuffer-go/v2/option"
-  )
+  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
+      RankBy: turbopuffer.NewRankByVector("vector", []float32{0.1, 0.2}),
+  })
   ```
+
+  New:
+
+  ```go
+  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
+      RankBy: turbopuffer.NewRankByAnn("vector", []float32{0.1, 0.2}),
+  })
+  ```
+
+- The `encryption` parameter has been restructured.
+
+  Old:
+
+  ```go
+  ns.Write(ctx, turbopuffer.NamespaceWriteParams{
+      UpsertRows: []turbopuffer.RowParam{ /* ... */ },
+      Encryption: turbopuffer.NamespaceWriteParamsEncryption{
+          Cmek: turbopuffer.NamespaceWriteParamsEncryptionCmek{KeyName: "..."},
+      },
+  })
+  ```
+
+  New:
+
+  ```go
+  ns.Write(ctx, turbopuffer.NamespaceWriteParams{
+      UpsertRows: []turbopuffer.RowParam{ /* ... */ },
+      Encryption: turbopuffer.EncryptionParamCustomerManaged("..."),
+  })
+  ```
+
+  A new `Default` variant lets you migrate a namespace from CMEK to default
+  encryption.
 
 - The `CopyFromNamespace` field on `NamespaceWriteParams` has been removed in
   favor of a dedicated `CopyFrom` method.
@@ -60,47 +93,14 @@ changes.
   })
   ```
 
-- The `encryption` parameter has been restructured.
-
-  Old:
-
-  ```go
-  ns.Write(ctx, turbopuffer.NamespaceWriteParams{
-      UpsertRows: []turbopuffer.RowParam{ /* ... */ },
-      Encryption: turbopuffer.NamespaceWriteParamsEncryption{
-          Cmek: turbopuffer.NamespaceWriteParamsEncryptionCmek{KeyName: "..."},
-      },
-  })
-  ```
-
-  New:
+- The module path has been bumped to `github.com/turbopuffer/turbopuffer-go/v2`.
+  Update your imports accordingly:
 
   ```go
-  ns.Write(ctx, turbopuffer.NamespaceWriteParams{
-      UpsertRows: []turbopuffer.RowParam{ /* ... */ },
-      Encryption: turbopuffer.EncryptionParamCustomerManaged("..."),
-  })
-  ```
-
-  A new `Default` variant lets you migrate a namespace from CMEK to default
-  encryption.
-
-- The `NewRankByVector` constructor has been renamed to `NewRankByAnn`.
-
-  Old:
-
-  ```go
-  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
-      RankBy: turbopuffer.NewRankByVector("vector", []float32{0.1, 0.2}),
-  })
-  ```
-
-  New:
-
-  ```go
-  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
-      RankBy: turbopuffer.NewRankByAnn("vector", []float32{0.1, 0.2}),
-  })
+  import (
+      "github.com/turbopuffer/turbopuffer-go/v2"
+      "github.com/turbopuffer/turbopuffer-go/v2/option"
+  )
   ```
 
 - `NamespaceQueryParams.GroupBy` is now `[]turbopuffer.GroupBy` instead of

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,16 @@ changes.
 
 ## v2.0
 
+- The module path has been bumped to `github.com/turbopuffer/turbopuffer-go/v2`.
+  Update your imports accordingly:
+
+  ```go
+  import (
+      "github.com/turbopuffer/turbopuffer-go/v2"
+      "github.com/turbopuffer/turbopuffer-go/v2/option"
+  )
+  ```
+
 - The `NewRankByVector` constructor has been renamed to `NewRankByAnn`.
 
   Old:
@@ -113,14 +123,4 @@ changes.
   ns.BranchFrom(ctx, turbopuffer.NamespaceBranchFromParams{
       SourceNamespace: "src",
   })
-  ```
-
-- The module path has been bumped to `github.com/turbopuffer/turbopuffer-go/v2`.
-  Update your imports accordingly:
-
-  ```go
-  import (
-      "github.com/turbopuffer/turbopuffer-go/v2"
-      "github.com/turbopuffer/turbopuffer-go/v2/option"
-  )
   ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -79,10 +79,8 @@ changes.
   })
   ```
 
-- The `Encryption` field on `NamespaceWriteParams` is now a discriminated union
-  (`EncryptionParam`) rather than an object with a `Cmek` field. A new
-  `Default` variant lets you explicitly opt out of CMEK on writes to a
-  CMEK-enabled namespace.
+- The `encryption` parameter has been restructured. A new `Default` variant
+  lets you explicitly opt out of CMEK on writes to a CMEK-enabled namespace.
 
   Old:
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,84 @@
+# Upgrade guide
+
+This document describes the notable breaking changes, if any, in each version of
+the Go client. See [CHANGELOG.md](./CHANGELOG.md) for a comprehensive list of
+changes.
+
+## v2.0
+
+- The module path has been bumped to `github.com/turbopuffer/turbopuffer-go/v2`.
+  Update your imports accordingly:
+
+  ```go
+  import (
+      "github.com/turbopuffer/turbopuffer-go/v2"
+      "github.com/turbopuffer/turbopuffer-go/v2/option"
+  )
+  ```
+
+- The `CopyFromNamespace` field on `NamespaceWriteParams` has been removed in
+  favor of a dedicated `CopyFrom` method.
+
+  Old:
+
+  ```go
+  ns.Write(ctx, turbopuffer.NamespaceWriteParams{
+      CopyFromNamespace: turbopuffer.CopyFromNamespaceParams{
+          SourceNamespace: "src",
+          SourceRegion:    turbopuffer.String("gcp-us-central1"),
+      },
+  })
+  ```
+
+  New:
+
+  ```go
+  ns.CopyFrom(ctx, turbopuffer.NamespaceCopyFromParams{
+      SourceNamespace: "src",
+      SourceRegion:    turbopuffer.String("gcp-us-central1"),
+  })
+  ```
+
+- The `BranchFromNamespace` field on `NamespaceWriteParams` has been removed in
+  favor of a dedicated `BranchFrom` method.
+
+  Old:
+
+  ```go
+  ns.Write(ctx, turbopuffer.NamespaceWriteParams{
+      BranchFromNamespace: turbopuffer.BranchFromNamespaceParams{
+          SourceNamespace: "src",
+      },
+  })
+  ```
+
+  New:
+
+  ```go
+  ns.BranchFrom(ctx, turbopuffer.NamespaceBranchFromParams{
+      SourceNamespace: "src",
+  })
+  ```
+
+- The element type of `NamespaceMultiQueryParams.Queries` has been renamed from
+  `QueryParam` to `NamespaceMultiQueryParamsQuery`.
+
+  Old:
+
+  ```go
+  ns.MultiQuery(ctx, turbopuffer.NamespaceMultiQueryParams{
+      Queries: []turbopuffer.QueryParam{ /* ... */ },
+  })
+  ```
+
+  New:
+
+  ```go
+  ns.MultiQuery(ctx, turbopuffer.NamespaceMultiQueryParams{
+      Queries: []turbopuffer.NamespaceMultiQueryParamsQuery{ /* ... */ },
+  })
+  ```
+
+## v1.0
+
+No significant changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -101,5 +101,5 @@ changes.
   })
   ```
 
-  A new `Default` variant lets you explicitly opt out of CMEK on writes to a
-  CMEK-enabled namespace.
+  A new `Default` variant lets you migrate a namespace from CMEK to default
+  encryption.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -79,8 +79,7 @@ changes.
   })
   ```
 
-- The `encryption` parameter has been restructured. A new `Default` variant
-  lets you explicitly opt out of CMEK on writes to a CMEK-enabled namespace.
+- The `encryption` parameter has been restructured.
 
   Old:
 
@@ -101,6 +100,9 @@ changes.
       Encryption: turbopuffer.EncryptionParamCustomerManaged("..."),
   })
   ```
+
+  A new `Default` variant lets you explicitly opt out of CMEK on writes to a
+  CMEK-enabled namespace.
 
 ## v1.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -79,6 +79,31 @@ changes.
   })
   ```
 
+- The `Encryption` field on `NamespaceWriteParams` is now a discriminated union
+  (`EncryptionParam`) rather than an object with a `Cmek` field. A new
+  `Default` variant lets you explicitly opt out of CMEK on writes to a
+  CMEK-enabled namespace.
+
+  Old:
+
+  ```go
+  ns.Write(ctx, turbopuffer.NamespaceWriteParams{
+      UpsertRows: []turbopuffer.RowParam{ /* ... */ },
+      Encryption: turbopuffer.NamespaceWriteParamsEncryption{
+          Cmek: turbopuffer.NamespaceWriteParamsEncryptionCmek{KeyName: "..."},
+      },
+  })
+  ```
+
+  New:
+
+  ```go
+  ns.Write(ctx, turbopuffer.NamespaceWriteParams{
+      UpsertRows: []turbopuffer.RowParam{ /* ... */ },
+      Encryption: turbopuffer.EncryptionParamCustomerManaged("..."),
+  })
+  ```
+
 ## v1.0
 
 No significant changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -103,7 +103,3 @@ changes.
 
   A new `Default` variant lets you explicitly opt out of CMEK on writes to a
   CMEK-enabled namespace.
-
-## v1.0
-
-No significant changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -60,25 +60,6 @@ changes.
   })
   ```
 
-- The element type of `NamespaceMultiQueryParams.Queries` has been renamed from
-  `QueryParam` to `NamespaceMultiQueryParamsQuery`.
-
-  Old:
-
-  ```go
-  ns.MultiQuery(ctx, turbopuffer.NamespaceMultiQueryParams{
-      Queries: []turbopuffer.QueryParam{ /* ... */ },
-  })
-  ```
-
-  New:
-
-  ```go
-  ns.MultiQuery(ctx, turbopuffer.NamespaceMultiQueryParams{
-      Queries: []turbopuffer.NamespaceMultiQueryParamsQuery{ /* ... */ },
-  })
-  ```
-
 - The `encryption` parameter has been restructured.
 
   Old:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -84,3 +84,28 @@ changes.
 
   A new `Default` variant lets you migrate a namespace from CMEK to default
   encryption.
+
+- The `NewRankByVector` and `NewRankBySparseVector` constructors have been
+  renamed to `NewRankByAnn` and `NewRankBySparseKnn`.
+
+- `NamespaceQueryParams.GroupBy` is now `[]turbopuffer.GroupBy` instead of
+  `[]string`. Wrap plain attribute names with `turbopuffer.NewGroupByAttr`.
+
+  Old:
+
+  ```go
+  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
+      GroupBy: []string{"color", "size"},
+  })
+  ```
+
+  New:
+
+  ```go
+  ns.Query(ctx, turbopuffer.NamespaceQueryParams{
+      GroupBy: []turbopuffer.GroupBy{
+          turbopuffer.NewGroupByAttr("color"),
+          turbopuffer.NewGroupByAttr("size"),
+      },
+  })
+  ```


### PR DESCRIPTION
Adds an UPGRADING.md modeled after the Python and TypeScript clients. Documents the v2.0 breaking changes inferred from the docs samples:

- Module path bumped to `github.com/turbopuffer/turbopuffer-go/v2`.
- `CopyFromNamespace` write field replaced by a dedicated `CopyFrom` method.
- `BranchFromNamespace` write field replaced by a dedicated `BranchFrom` method.
- `NamespaceMultiQueryParams.Queries` element type renamed to `NamespaceMultiQueryParamsQuery`.

Also adds a stub v1.0 entry noting no significant changes.