### PR TITLE
feat: transparent async polling

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/turbopuffer/turbopuffer-go/v2/internal"
 	"github.com/turbopuffer/turbopuffer-go/v2/internal/requestconfig"
+	"github.com/turbopuffer/turbopuffer-go/v2/internal/respondasync"
 	"github.com/turbopuffer/turbopuffer-go/v2/option"
 	"github.com/turbopuffer/turbopuffer-go/v2/packages/pagination"
 )
@@ -59,6 +60,7 @@ func DefaultClientOptions() []option.RequestOption {
 // option will be passed down to the services and requests that this client makes.
 func NewClient(opts ...option.RequestOption) (r Client) {
 	opts = append(DefaultClientOptions(), opts...)
+	opts = append([]option.RequestOption{respondasync.NewOption(opts)}, opts...)
 
 	r = Client{
 		Options:    opts,

--- a/internal/respondasync/respondasync.go
+++ b/internal/respondasync/respondasync.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"slices"
@@ -60,15 +61,15 @@ func (m *middleware) maybePoll(origReq *http.Request, res *http.Response) (*http
 		return res, nil
 	}
 
-	location := res.Header.Get(headerLocation)
-	if location == "" {
-		return res, errors.New("server returned async response without a `Location` header")
-	}
-
 	// Drain and close the body, to prevent connection leaking.
 	if res.Body != nil {
 		_, _ = io.Copy(io.Discard, res.Body)
 		_ = res.Body.Close()
+	}
+
+	location := res.Header.Get(headerLocation)
+	if location == "" {
+		return res, errors.New("server returned async response without a `Location` header")
 	}
 
 	ctx := origReq.Context()
@@ -147,6 +148,9 @@ func resolvePollResponse(body []byte) (*http.Response, error) {
 		statusCode = http.StatusOK
 		responseBody = parsed.Result.Success
 	case parsed.Result.Error != nil:
+		if parsed.Result.Error.StatusCode == 0 {
+			return nil, errMalformedPollResponse
+		}
 		statusCode = parsed.Result.Error.StatusCode
 		responseBody = parsed.Result.Error.Detail
 	default:
@@ -154,8 +158,11 @@ func resolvePollResponse(body []byte) (*http.Response, error) {
 	}
 
 	return &http.Response{
-		Status:     http.StatusText(statusCode),
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
 		StatusCode: statusCode,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
 		Header: http.Header{
 			"Content-Type": {"application/json"},
 			// Prevent the outer retry loop from starting another

--- a/internal/respondasync/respondasync.go
+++ b/internal/respondasync/respondasync.go
@@ -1,0 +1,167 @@
+// Package respondasync implements transparent polling for tpuf APIs that
+// accept `prefer: respond-async`.
+//
+// Every API request is stamped with `prefer: respond-async`. If the server
+// applies the preference (i.e. responds with `202 Accepted` +
+// `preference-applied: respond-async`) the SDK polls the operation URL until
+// it finishes and returns the final result as if the call had been
+// synchronous.
+package respondasync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/turbopuffer/turbopuffer-go/v2/internal/requestconfig"
+	"github.com/turbopuffer/turbopuffer-go/v2/option"
+)
+
+const (
+	headerPrefer            = "Prefer"
+	headerPreferenceApplied = "Preference-Applied"
+	headerLocation          = "Location"
+	respondAsync            = "respond-async"
+)
+
+var PollInterval = 1 * time.Second
+
+func NewOption(clientOpts []option.RequestOption) option.RequestOption {
+	m := &middleware{clientOpts: slices.Clone(clientOpts)}
+	return option.WithMiddleware(m.handle)
+}
+
+type middleware struct {
+	clientOpts []option.RequestOption
+}
+
+func (m *middleware) handle(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+	// Don't overwrite an existing `prefer` header. This allows the caller
+	// to disable async mode.
+	if _, ok := req.Header[http.CanonicalHeaderKey(headerPrefer)]; !ok {
+		req.Header.Set(headerPrefer, respondAsync)
+	}
+
+	res, err := next(req)
+	if err != nil {
+		return res, err
+	}
+	return m.maybePoll(req, res)
+}
+
+func (m *middleware) maybePoll(origReq *http.Request, res *http.Response) (*http.Response, error) {
+	if !respondAsyncApplied(res) {
+		return res, nil
+	}
+
+	location := res.Header.Get(headerLocation)
+	if location == "" {
+		return res, errors.New("server returned async response without a `Location` header")
+	}
+
+	// Drain and close the body, to prevent connection leaking.
+	if res.Body != nil {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}
+
+	ctx := origReq.Context()
+	for {
+		body, err := m.pollOnce(ctx, location)
+		if err != nil {
+			return res, err
+		}
+		finalRes, err := resolvePollResponse(body)
+		if err != nil {
+			return res, err
+		}
+		if finalRes != nil {
+			return finalRes, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return res, ctx.Err()
+		case <-time.After(PollInterval):
+		}
+	}
+}
+
+func respondAsyncApplied(res *http.Response) bool {
+	if res == nil || res.StatusCode != http.StatusAccepted {
+		return false
+	}
+	return strings.EqualFold(res.Header.Get(headerPreferenceApplied), respondAsync)
+}
+
+func (m *middleware) pollOnce(ctx context.Context, location string) ([]byte, error) {
+	var res *http.Response
+	opts := append(slices.Clone(m.clientOpts), option.WithResponseBodyInto(&res))
+	if err := requestconfig.ExecuteNewRequest(ctx, http.MethodGet, location, nil, nil, opts...); err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	return io.ReadAll(res.Body)
+}
+
+type pollBody struct {
+	Status string      `json:"status"`
+	Result *pollResult `json:"result"`
+}
+
+type pollResult struct {
+	Success json.RawMessage `json:"success"`
+	Error   *pollError      `json:"error"`
+}
+
+type pollError struct {
+	StatusCode int             `json:"status_code"`
+	Detail     json.RawMessage `json:"detail"`
+}
+
+var errMalformedPollResponse = errors.New("malformed poll response")
+
+func resolvePollResponse(body []byte) (*http.Response, error) {
+	var parsed pollBody
+
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, errMalformedPollResponse
+	}
+	if parsed.Status == "running" {
+		return nil, nil
+	}
+	if parsed.Status != "finished" || parsed.Result == nil {
+		return nil, errMalformedPollResponse
+	}
+
+	var statusCode int
+	var responseBody []byte
+	switch {
+	case parsed.Result.Success != nil:
+		statusCode = http.StatusOK
+		responseBody = parsed.Result.Success
+	case parsed.Result.Error != nil:
+		statusCode = parsed.Result.Error.StatusCode
+		responseBody = parsed.Result.Error.Detail
+	default:
+		return nil, errMalformedPollResponse
+	}
+
+	return &http.Response{
+		Status:     http.StatusText(statusCode),
+		StatusCode: statusCode,
+		Header: http.Header{
+			"Content-Type": {"application/json"},
+			// Prevent the outer retry loop from starting another
+			// async operation.
+			"X-Should-Retry": {"false"},
+		},
+		Body: io.NopCloser(bytes.NewReader(responseBody)),
+	}, nil
+}

--- a/respondasync_test.go
+++ b/respondasync_test.go
@@ -1,0 +1,290 @@
+package turbopuffer_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"maps"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/turbopuffer/turbopuffer-go/v2"
+	"github.com/turbopuffer/turbopuffer-go/v2/internal/respondasync"
+	"github.com/turbopuffer/turbopuffer-go/v2/option"
+)
+
+const (
+	baseURL = "http://localhost:5000"
+	pollURL = baseURL + "/v1/namespaces/test/operations/op-abc"
+)
+
+var writeOK = `{
+	"billing": {"billable_logical_bytes_written": 0, "billable_logical_bytes_returned": 0},
+	"message": "OK",
+	"rows_affected": 1,
+	"status": "OK"
+}`
+
+func fastPollInterval(t *testing.T) {
+	t.Helper()
+	prev := respondasync.PollInterval
+	respondasync.PollInterval = 0
+	t.Cleanup(func() { respondasync.PollInterval = prev })
+}
+
+func makeResponse(status int, body string, headers http.Header) *http.Response {
+	h := http.Header{"Content-Type": {"application/json"}}
+	maps.Copy(h, headers)
+	return &http.Response{
+		StatusCode: status,
+		Header:     h,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+}
+
+func asyncAcceptedResponse(location string) *http.Response {
+	return makeResponse(http.StatusAccepted, "", http.Header{
+		"Preference-Applied": {"respond-async"},
+		"Location":           {location},
+	})
+}
+
+func newClient(rt http.RoundTripper, opts ...option.RequestOption) turbopuffer.Client {
+	base := []option.RequestOption{
+		option.WithBaseURL(baseURL),
+		option.WithAPIKey("tpuf_A1..."),
+		option.WithHTTPClient(&http.Client{Transport: rt}),
+	}
+	return turbopuffer.NewClient(append(base, opts...)...)
+}
+
+func writeParams() turbopuffer.NamespaceWriteParams {
+	return turbopuffer.NamespaceWriteParams{
+		UpsertRows: []turbopuffer.RowParam{
+			{"id": "2108ed60-6851-49a0-9016-8325434f3845", "vector": []float32{0.1, 0.2}},
+		},
+	}
+}
+
+func TestRespondAsyncPreferHeaderSent(t *testing.T) {
+	var preferHeader string
+	client := newClient(&closureTransport{
+		fn: func(req *http.Request) (*http.Response, error) {
+			preferHeader = req.Header.Get("Prefer")
+			return makeResponse(http.StatusOK, writeOK, nil), nil
+		},
+	})
+	ns := client.Namespace("test")
+	if _, err := ns.Write(context.Background(), writeParams()); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if preferHeader != "respond-async" {
+		t.Errorf("expected `prefer: respond-async`, got %q", preferHeader)
+	}
+}
+
+func TestRespondAsyncSyncResponsePassthrough(t *testing.T) {
+	calls := 0
+	client := newClient(&closureTransport{
+		fn: func(req *http.Request) (*http.Response, error) {
+			calls++
+			return makeResponse(http.StatusOK, writeOK, nil), nil
+		},
+	})
+	ns := client.Namespace("test")
+	res, err := ns.Write(context.Background(), writeParams())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 request, got %d", calls)
+	}
+	if res.RowsAffected != 1 {
+		t.Errorf("expected rows_affected=1, got %d", res.RowsAffected)
+	}
+}
+
+func TestRespondAsyncUnrelated202Passthrough(t *testing.T) {
+	calls := 0
+	client := newClient(&closureTransport{
+		fn: func(req *http.Request) (*http.Response, error) {
+			calls++
+			return makeResponse(http.StatusAccepted, writeOK, nil), nil
+		},
+	})
+	ns := client.Namespace("test")
+	res, err := ns.Write(context.Background(), writeParams())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 request, got %d", calls)
+	}
+	if res.Status != "OK" {
+		t.Errorf("expected status OK, got %q", res.Status)
+	}
+}
+
+func TestRespondAsyncPolledToSuccess(t *testing.T) {
+	fastPollInterval(t)
+	responses := []*http.Response{
+		asyncAcceptedResponse(pollURL),
+		makeResponse(http.StatusOK, `{"status":"running"}`, nil),
+		makeResponse(http.StatusOK, `{"status":"running"}`, nil),
+		makeResponse(http.StatusOK, `{"status":"finished","result":{"success":`+writeOK+`}}`, nil),
+	}
+	var requests []*http.Request
+	client := newClient(&closureTransport{
+		fn: func(req *http.Request) (*http.Response, error) {
+			if len(requests) >= len(responses) {
+				t.Fatalf("unexpected request #%d: %s %s", len(requests)+1, req.Method, req.URL)
+			}
+			requests = append(requests, req)
+			return responses[len(requests)-1], nil
+		},
+	})
+	ns := client.Namespace("test")
+	res, err := ns.Write(context.Background(), writeParams())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(requests) != 4 {
+		t.Errorf("expected 4 requests, got %d", len(requests))
+	}
+	if res.RowsAffected != 1 {
+		t.Errorf("expected rows_affected=1, got %d", res.RowsAffected)
+	}
+	for i := 1; i < len(requests); i++ {
+		req := requests[i]
+		if got := req.URL.String(); got != pollURL {
+			t.Errorf("poll #%d URL = %q, want %q", i, got, pollURL)
+		}
+		if req.Method != http.MethodGet {
+			t.Errorf("poll #%d method = %s, want GET", i, req.Method)
+		}
+		if auth := req.Header.Get("Authorization"); !strings.HasPrefix(auth, "Bearer ") {
+			t.Errorf("poll #%d missing Authorization header, got %q", i, auth)
+		}
+		if got := req.Header.Get("Prefer"); got != "" {
+			t.Errorf("poll #%d should not send Prefer, got %q", i, got)
+		}
+	}
+}
+
+func TestRespondAsyncErrorResultThrowsStatusError(t *testing.T) {
+	fastPollInterval(t)
+	responses := []*http.Response{
+		asyncAcceptedResponse(pollURL),
+		makeResponse(http.StatusOK,
+			`{"status":"finished","result":{"error":{"status_code":404,"detail":{"message":"namespace not found"}}}}`,
+			nil),
+	}
+	calls := 0
+	client := newClient(&closureTransport{
+		fn: func(req *http.Request) (*http.Response, error) {
+			if calls >= len(responses) {
+				t.Fatalf("unexpected request #%d: %s %s", calls+1, req.Method, req.URL)
+			}
+			res := responses[calls]
+			calls++
+			return res, nil
+		},
+	})
+	ns := client.Namespace("test")
+	_, err := ns.Write(context.Background(), writeParams())
+	var apierr *turbopuffer.Error
+	if !errors.As(err, &apierr) {
+		t.Fatalf("expected *turbopuffer.Error, got %T: %v", err, err)
+	}
+	if apierr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", apierr.StatusCode)
+	}
+	if !strings.Contains(apierr.RawJSON(), "namespace not found") {
+		t.Errorf("expected error detail in raw JSON, got %q", apierr.RawJSON())
+	}
+}
+
+func TestRespondAsyncTransientPollErrorRetried(t *testing.T) {
+	fastPollInterval(t)
+	responses := []*http.Response{
+		asyncAcceptedResponse(pollURL),
+		makeResponse(http.StatusServiceUnavailable, "", http.Header{"Retry-After-Ms": {"0"}}),
+		makeResponse(http.StatusServiceUnavailable, "", http.Header{"Retry-After-Ms": {"0"}}),
+		makeResponse(http.StatusOK, `{"status":"finished","result":{"success":`+writeOK+`}}`, nil),
+	}
+	calls := 0
+	client := newClient(&closureTransport{
+		fn: func(req *http.Request) (*http.Response, error) {
+			if calls >= len(responses) {
+				t.Fatalf("unexpected request #%d: %s %s", calls+1, req.Method, req.URL)
+			}
+			res := responses[calls]
+			calls++
+			return res, nil
+		},
+	})
+	ns := client.Namespace("test")
+	res, err := ns.Write(context.Background(), writeParams())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if calls != 4 {
+		t.Errorf("expected 4 requests, got %d", calls)
+	}
+	if res.RowsAffected != 1 {
+		t.Errorf("expected rows_affected=1, got %d", res.RowsAffected)
+	}
+}
+
+func TestRespondAsyncPollTimeout(t *testing.T) {
+	fastPollInterval(t)
+	calls := 0
+	client := newClient(&closureTransport{
+		fn: func(req *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return asyncAcceptedResponse(pollURL), nil
+			}
+			return makeResponse(http.StatusOK, `{"status":"running"}`, nil), nil
+		},
+	}, option.WithRequestTimeout(50*time.Millisecond))
+	ns := client.Namespace("test")
+	_, err := ns.Write(context.Background(), writeParams())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestRespondAsyncPersistentPollErrorThrows(t *testing.T) {
+	fastPollInterval(t)
+	responses := []*http.Response{
+		asyncAcceptedResponse(pollURL),
+		makeResponse(http.StatusInternalServerError, "", nil),
+	}
+	calls := 0
+	client := newClient(&closureTransport{
+		fn: func(req *http.Request) (*http.Response, error) {
+			if calls >= len(responses) {
+				t.Fatalf("unexpected request #%d: %s %s", calls+1, req.Method, req.URL)
+			}
+			res := responses[calls]
+			calls++
+			return res, nil
+		},
+	}, option.WithMaxRetries(0))
+	ns := client.Namespace("test")
+	_, err := ns.Write(context.Background(), writeParams())
+	var apierr *turbopuffer.Error
+	if !errors.As(err, &apierr) {
+		t.Fatalf("expected *turbopuffer.Error, got %T: %v", err, err)
+	}
+	if apierr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", apierr.StatusCode)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 requests (no retries), got %d", calls)
+	}
+}


### PR DESCRIPTION
This adds support for transparent async polling against tpuf APIs that support it. The SDK unconditionally set the `prefer: respond-async` header on all API calls, then detects and handles async responses by polling them until the final state.

In contrast to the prior work (https://github.com/turbopuffer/turbopuffer-python/pull/230, https://github.com/turbopuffer/turbopuffer-typescript/pull/210) this doesn't hook into the request processing directly but is instead implemented as a middleware. I tried hooking into `RequestConfig.Execute()`, but from there it wasn't easy to make HTTP requests that use the same options as the initial request. The middleware approach turns out cleaner, at the cost of being inconsistent with the other two SDKs.