### PR TITLE
chore: fix API docs links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Full Changelog: [v2.1.0...v2.2.0](https://github.com/turbopuffer/turbopuffer-go/
 
 ### Features
 
-* rename /docs/auth to /docs/overview ([86bfd6a](https://github.com/turbopuffer/turbopuffer-go/commit/86bfd6a007ef00a0cf5ef9ad971b109d7e6a79a4))
 * spec: force generation of FuzzyParams stainless models ([dc75877](https://github.com/turbopuffer/turbopuffer-go/commit/dc75877336d94ac920881299f92157f4b81d5c02))
 * transparent async polling ([#119](https://github.com/turbopuffer/turbopuffer-go/issues/119)) ([7dcd309](https://github.com/turbopuffer/turbopuffer-go/commit/7dcd3098ba6bea7c7080047caf8ee6c233563161))
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is generated with [Stainless](https://www.stainless.com/).
 
 ## Documentation
 
-The HTTP API documentation can be found at [turbopuffer.com/docs](https://turbopuffer.com/docs/auth).
+The HTTP API documentation can be found at [turbopuffer.com/docs/overview](https://turbopuffer.com/docs/overview).
 
 The full API of this library can be found at
 <https://pkg.go.dev/github.com/turbopuffer/turbopuffer-go>.


### PR DESCRIPTION
Renames `/docs/auth` -> `/docs/overview` everywhere.