### PR TITLE
fix: reject malicious poll locations

### DIFF
--- a/internal/respondasync/respondasync.go
+++ b/internal/respondasync/respondasync.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -67,9 +68,9 @@ func (m *middleware) maybePoll(origReq *http.Request, res *http.Response) (*http
 		_ = res.Body.Close()
 	}
 
-	location := res.Header.Get(headerLocation)
-	if location == "" {
-		return res, errors.New("server returned async response without a `Location` header")
+	location, err := extractLocation(res, origReq.URL)
+	if err != nil {
+		return res, err
 	}
 
 	ctx := origReq.Context()
@@ -92,6 +93,26 @@ func (m *middleware) maybePoll(origReq *http.Request, res *http.Response) (*http
 		case <-time.After(PollInterval):
 		}
 	}
+}
+
+func extractLocation(res *http.Response, origURL *url.URL) (string, error) {
+	rawLocation := res.Header.Get(headerLocation)
+	if rawLocation == "" {
+		return "", errors.New("server returned async response without a 'Location' header")
+	}
+
+	// Resolve the Location against the original request URL.
+	resolved, err := origURL.Parse(rawLocation)
+	if err != nil {
+		return "", fmt.Errorf("malformed 'Location' header: %q", rawLocation)
+	}
+
+	// Reject a Location pointing at a different origin, to prevent API key exfiltration.
+	if resolved.Scheme != origURL.Scheme || resolved.Host != origURL.Host {
+		return "", fmt.Errorf("'Location' origin does not match request origin: %q", rawLocation)
+	}
+
+	return resolved.String(), nil
 }
 
 func respondAsyncApplied(res *http.Response) bool {

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -469,8 +469,8 @@ func TestNamespaceWriteWithOptionalParams(t *testing.T) {
 					Attribute: turbopuffer.String("attribute"),
 					Dims:      turbopuffer.Int(0),
 				}, Filterable: turbopuffer.Bool(true), FullTextSearch: &turbopuffer.FullTextSearchConfigParam{B: turbopuffer.Float(0), CaseSensitive: turbopuffer.Bool(true), K1: turbopuffer.Float(0), Language: turbopuffer.LanguageArabic, RemoveStopwords: turbopuffer.Bool(true), Stemming: turbopuffer.Bool(true), Tokenizer: turbopuffer.TokenizerPreTokenizedArray}, Fuzzy: turbopuffer.Bool(true), Glob: turbopuffer.Bool(true), Type: turbopuffer.AttributeType("string"), SparseKnn: turbopuffer.AttributeSchemaConfigSparseKnnParam{
-				DistanceMetric: turbopuffer.SparseDistanceMetricDotProduct,
-			}},
+					DistanceMetric: turbopuffer.SparseDistanceMetricDotProduct,
+				}},
 		},
 		UpsertColumns:   turbopuffer.ColumnsParam{},
 		UpsertRows:      []turbopuffer.RowParam{},

--- a/respondasync_test.go
+++ b/respondasync_test.go
@@ -174,6 +174,33 @@ func TestRespondAsyncPolledToSuccess(t *testing.T) {
 	}
 }
 
+func TestRespondAsyncBadLocationRejected(t *testing.T) {
+	badLocations := []string{
+		"https://evil.example.com/v1/ops/op-x",
+		"//evil.example.com/v1/ops/op-x",
+		"http://api.turbopuffer.com/v1/ops/op-x",
+		"http://host:notaport/x",
+	}
+	for _, bad := range badLocations {
+		t.Run(bad, func(t *testing.T) {
+			calls := 0
+			client := newClient(&closureTransport{
+				fn: func(req *http.Request) (*http.Response, error) {
+					calls++
+					return asyncAcceptedResponse(bad), nil
+				},
+			})
+			ns := client.Namespace("test")
+			if _, err := ns.Write(context.Background(), writeParams()); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if calls != 1 {
+				t.Errorf("expected 1 request, got %d", calls)
+			}
+		})
+	}
+}
+
 func TestRespondAsyncErrorResultThrowsStatusError(t *testing.T) {
 	fastPollInterval(t)
 	responses := []*http.Response{


### PR DESCRIPTION
This fixes a minor security issue where the client wouldn't check the origin of the async response `Location` header before starting to poll it, allowing a man-in-the-middle to send poll requests (including API credentials) to arbitrary locations. This is a minor security issue, as such a man-in-the-middle would likely already know the API credentials from observing the initial authenticated request.

The fix is to compare the poll origin with the one from the original request, and reject if they differ.