### PR TITLE
fix: type rerank_by parameter as RerankBy

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -2044,7 +2044,7 @@ type NamespaceMultiQueryParams struct {
 	// The consistency level for a query.
 	Consistency NamespaceMultiQueryParamsConsistency `json:"consistency,omitzero"`
 	// How to combine the rows returned by each sub-query into a single ranked list.
-	RerankBy any `json:"rerank_by,omitzero"`
+	RerankBy RerankBy `json:"rerank_by,omitzero"`
 	// The encoding to use for vectors in the response.
 	//
 	// Any of "float", "base64".

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -221,7 +221,7 @@ func TestNamespaceMultiQueryWithOptionalParams(t *testing.T) {
 		Consistency: turbopuffer.NamespaceMultiQueryParamsConsistency{
 			Level: "strong",
 		},
-		RerankBy:       map[string]any{},
+		RerankBy:       turbopuffer.NewRerankByRrf(),
 		VectorEncoding: turbopuffer.VectorEncodingFloat,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Stainless leaves the `RerankBy` field typed as `any`. This wires it to the already-generated `RerankBy` interface (with `RerankByRrf` / `RerankByRrfWithParams` implementations) so callers get a proper signature.

## Test plan
- [x] `go vet ./...` passes
- [x] Updated generated test that previously used `map[string]any{}` to `turbopuffer.NewRerankByRrf()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)