### PR TITLE
spec: using typed version of `ComputeAttributes` for `compute_attributes`

### DIFF
--- a/custom_test.go
+++ b/custom_test.go
@@ -150,3 +150,32 @@ func TestToParamSerialization(t *testing.T) {
 		})
 	}
 }
+
+// TestComputeAttributesSerialization verifies that each variant of the
+// ComputeAttributes union serializes to its expected turbolisp wire format
+// when used as a value of the compute_attributes map. compute_attributes is a
+// request-only param, so this asserts the marshaled JSON rather than a full
+// round-trip.
+func TestComputeAttributesSerialization(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		val  turbopuffer.ComputeAttributes
+		want string
+	}{
+		{"vector_dist", turbopuffer.NewComputeAttributesVectorDist("vec", []float32{0.5}), `["vec","VectorDist",[0.5]]`},
+		{"highlight", turbopuffer.NewComputeAttributesHighlight("body"), `["Highlight","body"]`},
+		{"highlight_with_config", turbopuffer.NewComputeAttributesHighlightWithConfig("body", turbopuffer.HighlightConfigParams{}), `["Highlight","body",{}]`},
+		{"score_rank_by", turbopuffer.NewRankByAnn("vec", []float32{0.5}), `["vec","ANN",[0.5]]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(map[string]turbopuffer.ComputeAttributes{"attr": tc.val})
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := `{"attr":` + tc.want + `}`
+			if string(got) != want {
+				t.Fatalf("compute_attributes[%s]: got %s, want %s", tc.name, got, want)
+			}
+		})
+	}
+}

--- a/namespace.go
+++ b/namespace.go
@@ -2078,7 +2078,7 @@ type NamespaceExplainQueryParams struct {
 	// Computes additional values on documents returned by a query. Each key is the
 	// name of the computed attribute; each value is an expression describing how to
 	// compute it.
-	ComputeAttributes map[string]any `json:"compute_attributes,omitzero"`
+	ComputeAttributes map[string]ComputeAttributes `json:"compute_attributes,omitzero"`
 	// The consistency level for a query.
 	Consistency NamespaceExplainQueryParamsConsistency `json:"consistency,omitzero"`
 	// A function used to calculate vector similarity.
@@ -2192,7 +2192,7 @@ type NamespaceMultiQueryParamsQuery struct {
 	// Computes additional values on documents returned by a query. Each key is the
 	// name of the computed attribute; each value is an expression describing how to
 	// compute it.
-	ComputeAttributes map[string]any `json:"compute_attributes,omitzero"`
+	ComputeAttributes map[string]ComputeAttributes `json:"compute_attributes,omitzero"`
 	// A function used to calculate vector similarity.
 	//
 	// Any of "cosine_distance", "euclidean_squared".
@@ -2250,7 +2250,7 @@ type NamespaceQueryParams struct {
 	// Computes additional values on documents returned by a query. Each key is the
 	// name of the computed attribute; each value is an expression describing how to
 	// compute it.
-	ComputeAttributes map[string]any `json:"compute_attributes,omitzero"`
+	ComputeAttributes map[string]ComputeAttributes `json:"compute_attributes,omitzero"`
 	// The consistency level for a query.
 	Consistency NamespaceQueryParamsConsistency `json:"consistency,omitzero"`
 	// A function used to calculate vector similarity.

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -114,8 +114,8 @@ func TestNamespaceExplainQueryWithOptionalParams(t *testing.T) {
 	ns := client.Namespace("ns")
 	_, err := ns.ExplainQuery(context.TODO(), turbopuffer.NamespaceExplainQueryParams{
 		Namespace: turbopuffer.String("namespace"),
-		ComputeAttributes: map[string]any{
-			"foo": "bar",
+		ComputeAttributes: map[string]turbopuffer.ComputeAttributes{
+			"foo": turbopuffer.NewComputeAttributesHighlight("bar"),
 		},
 		Consistency: turbopuffer.NamespaceExplainQueryParamsConsistency{
 			Level: "strong",
@@ -213,8 +213,8 @@ func TestNamespaceMultiQueryWithOptionalParams(t *testing.T) {
 			AggregateBy: map[string]any{
 				"foo": "bar",
 			},
-			ComputeAttributes: map[string]any{
-				"foo": "bar",
+			ComputeAttributes: map[string]turbopuffer.ComputeAttributes{
+				"foo": turbopuffer.NewComputeAttributesHighlight("bar"),
 			},
 			DistanceMetric:    turbopuffer.DistanceMetricCosineDistance,
 			ExcludeAttributes: []string{"string"},
@@ -263,8 +263,8 @@ func TestNamespaceQueryWithOptionalParams(t *testing.T) {
 	ns := client.Namespace("ns")
 	_, err := ns.Query(context.TODO(), turbopuffer.NamespaceQueryParams{
 		Namespace: turbopuffer.String("namespace"),
-		ComputeAttributes: map[string]any{
-			"foo": "bar",
+		ComputeAttributes: map[string]turbopuffer.ComputeAttributes{
+			"foo": turbopuffer.NewComputeAttributesHighlight("bar"),
 		},
 		Consistency: turbopuffer.NamespaceQueryParamsConsistency{
 			Level: "strong",


### PR DESCRIPTION
Hand-types the `compute_attributes` query param as the rich `map[string]ComputeAttributes` union instead of `map[string]any`, in all three request-param structs in `namespace.go`:

- `NamespaceQueryParams`
- `NamespaceExplainQueryParams`
- `NamespaceMultiQueryParamsQuery`

This mirrors the existing `aggregate_by` -> `map[string]AggregateBy` typing in the same file. `ComputeAttributes` is a sealed-interface union already defined in `custom_types.go` with per-variant `MarshalJSON`, so these marshal-only request params serialize correctly.